### PR TITLE
Handle bytes.Buffer.ReadFrom errors in handlers.go

### DIFF
--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -766,12 +766,15 @@ func (v2 *Handlers) TealDryrun(ctx echo.Context) error {
 	req := ctx.Request()
 	buf := new(bytes.Buffer)
 	req.Body = http.MaxBytesReader(nil, req.Body, maxTealDryrunBytes)
-	buf.ReadFrom(req.Body)
+	_, err := buf.ReadFrom(ctx.Request().Body)
+	if err != nil {
+		return badRequest(ctx, err, err.Error(), v2.Log)
+	}
 	data := buf.Bytes()
 
 	var dr DryrunRequest
 	var gdr generated.DryrunRequest
-	err := decode(protocol.JSONStrictHandle, data, &gdr)
+	err = decode(protocol.JSONStrictHandle, data, &gdr)
 	if err == nil {
 		dr, err = DryrunRequestFromGenerated(&gdr)
 		if err != nil {
@@ -1136,7 +1139,10 @@ func (v2 *Handlers) TealCompile(ctx echo.Context) error {
 	}
 	buf := new(bytes.Buffer)
 	ctx.Request().Body = http.MaxBytesReader(nil, ctx.Request().Body, maxTealSourceBytes)
-	buf.ReadFrom(ctx.Request().Body)
+	_, err := buf.ReadFrom(ctx.Request().Body)
+	if err != nil {
+		return badRequest(ctx, err, err.Error(), v2.Log)
+	}
 	source := buf.String()
 	ops, err := logic.AssembleString(source)
 	if err != nil {
@@ -1162,7 +1168,10 @@ func (v2 *Handlers) TealDisassemble(ctx echo.Context) error {
 	}
 	buf := new(bytes.Buffer)
 	ctx.Request().Body = http.MaxBytesReader(nil, ctx.Request().Body, maxTealSourceBytes)
-	buf.ReadFrom(ctx.Request().Body)
+	_, err := buf.ReadFrom(ctx.Request().Body)
+	if err != nil {
+		return badRequest(ctx, err, err.Error(), v2.Log)
+	}
 	sourceProgram, err := base64.StdEncoding.DecodeString(buf.String())
 	if err != nil {
 		return badRequest(ctx, err, err.Error(), v2.Log)


### PR DESCRIPTION
Handles bytes.Buffer.ReadFrom errors in `daemon/algod/api/server/v2/handlers.go`. 

While reviewing https://github.com/algorand/go-algorand/pull/3908, I noticed several handlers do _not_ process errors when reading request body.  I don't have much prior Golang I/O exposure, so there might be a reason the error is _not_ processed.  Consider the PR optional.