### PR TITLE
Source Go version from go.mod

### DIFF
--- a/.github/workflows/pr-benchmarks.yml
+++ b/.github/workflows/pr-benchmarks.yml
@@ -7,12 +7,11 @@ jobs:
     name: Performance regression check
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Install go
-        uses: actions/setup-go@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
-          go-version: '1.17.9'
+          go-version-file: 'go.mod'
+      - run: go version
       - name: Build go-algorand
         run: scripts/travis/build.sh
       - name: Run benchmark


### PR DESCRIPTION
Sources Go version from `go.mod` to avoid duplicating Go version as discussed in https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file.

The PR's downside is that benchmarks will switch Go version based on the repo's changes rather than explicit changes to `.github/workflows/pr-benchmarks.yml`.  Since the intent is to capture _large_ performance deltas rather than minor deviations, it feels _reasonable_ to be less explicit.