### PR TITLE
Rename PendingTransactionsStruct to PendingTransactions

### DIFF
--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -983,14 +983,14 @@ func (c *Client) GetPendingTransactionsByAddress(addr string, maxTxns uint64) (r
 	return
 }
 
-// PendingTransactionsStruct represents a parsed PendingTransactionsResponse struct.
-type PendingTransactionsStruct struct {
+// PendingTransactions represents a parsed PendingTransactionsResponse struct.
+type PendingTransactions struct {
 	TopTransactions   []transactions.SignedTxn `json:"top-transactions"`
 	TotalTransactions uint64                   `json:"total-transactions"`
 }
 
 // GetParsedPendingTransactions returns the parsed response with pending transactions.
-func (c *Client) GetParsedPendingTransactions(maxTxns uint64) (txns PendingTransactionsStruct, err error) {
+func (c *Client) GetParsedPendingTransactions(maxTxns uint64) (txns PendingTransactions, err error) {
 	algod, err := c.ensureAlgodClient()
 	if err == nil {
 		var resp []byte
@@ -1006,7 +1006,7 @@ func (c *Client) GetParsedPendingTransactions(maxTxns uint64) (txns PendingTrans
 }
 
 // GetParsedPendingTransactionsByAddress returns the parsed response with pending transactions by address.
-func (c *Client) GetParsedPendingTransactionsByAddress(addr string, maxTxns uint64) (txns PendingTransactionsStruct, err error) {
+func (c *Client) GetParsedPendingTransactionsByAddress(addr string, maxTxns uint64) (txns PendingTransactions, err error) {
 	algod, err := c.ensureAlgodClient()
 	if err == nil {
 		var resp []byte


### PR DESCRIPTION
Extends https://github.com/algorand/go-algorand/pull/4684 to optionally propose renaming  `PendingTransactionsStruct` to `PendingTransactions`.  Unless there's a reason otherwise, the thinking is the `Struct` suffix is superfluous.

If you prefer as is, then feel welcomed to close the PR.